### PR TITLE
Pin chroot to debian 11

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -33,7 +33,7 @@ done
 popd
 
 sudo chown root:root ./root
-sudo debootstrap --include=$(IFS=,; echo "${deps[*]}") stable ./root
+sudo debootstrap --include=$(IFS=,; echo "${deps[*]}") bullseye ./root
 
 echo 'To enter the chroot:'
 echo '$ firejail --chroot=./root --net=none --private-cwd=/build'


### PR DESCRIPTION
Fixes #7. In this version, `libssl-dev` is 1.1.1w.