### PR TITLE
Update to mrustc 0.10.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,20 +4,18 @@ set -euo pipefail
 
 source /build/versions.sh
 
-cd "/build/rustc-${rustc_versions[0]}"
-echo "Patching rustc ${rustc_versions[0]}"
-patch -p0 <"../mrustc-${mrustc_version}/rustc-1.29.0-src.patch"
-
 cd "/build/mrustc-${mrustc_version}"
 export LIBSSH2_SYS_USE_PKG_CONFIG=true
-export MINICARGO_FLAGS="-j$(nproc)"
+export PARLEVEL="$(nproc)"
+export RUSTC_VERSION="${rustc_versions[0]}"
 echo "Building mrustc ${mrustc_version}"
 make -j$(nproc) -f minicargo.mk bin/mrustc
 echo "Building rustc ${rustc_versions[0]}"
-make -j$(nproc) -f minicargo.mk RUSTCSRC="../rustc-${rustc_versions[0]}/" output/rustc
-make -j$(nproc) -f minicargo.mk RUSTCSRC="../rustc-${rustc_versions[0]}/" output/cargo
+make -j$(nproc) -f minicargo.mk RUSTCSRC
+make -j$(nproc) -f minicargo.mk output/rustc
+make -j$(nproc) -f minicargo.mk output/cargo
 cd "/build/mrustc-${mrustc_version}/run_rustc"
-make -j$(nproc) RUST_SRC="../../rustc-${rustc_versions[0]}/src/"
+make -j$(nproc)
 
 export CARGO_HOME=/build/.cargo
 unset SUDO_USER

--- a/configs/rustc-1.30.1/config.toml
+++ b/configs/rustc-1.30.1/config.toml
@@ -1,6 +1,6 @@
 [build]
-cargo = "/build/mrustc-0.9/run_rustc/output/prefix/bin/cargo"
-rustc = "/build/mrustc-0.9/run_rustc/output/prefix/bin/rustc"
+cargo = "/build/mrustc-0.10.1/run_rustc/output/prefix/bin/cargo"
+rustc = "/build/mrustc-0.10.1/run_rustc/output/prefix/bin/rustc"
 docs = false
 vendor = true
 extended = true

--- a/init.sh
+++ b/init.sh
@@ -26,7 +26,8 @@ rsync -avP sources/ configs/ build.sh versions.sh root/build
 pushd root/build
 echo "Extracting mrustc ${mrustc_version}"
 tar xzf "mrustc-${mrustc_version}.tar.gz"
-for v in "${rustc_versions[@]}"; do
+ln -s "../rustc-${rustc_versions[0]}-src.tar.gz" "mrustc-${mrustc_version}"
+for v in "${rustc_versions[@]:1}"; do
     echo "Extracting rustc $v"
     mkdir -p "rustc-$v"
     tar xzf "rustc-$v-src.tar.gz" -C "rustc-$v" --strip-components 1

--- a/versions.sh
+++ b/versions.sh
@@ -1,6 +1,6 @@
-mrustc_version=0.9
+mrustc_version=0.10.1
 rustc_versions=(
-    1.29.2
+    1.29.0
     1.30.1
     1.31.1
     1.32.0


### PR DESCRIPTION
This also requires downgrading 1.29.2 to 1.29.0, as mrustc 0.10.1 contains a patch that fails to apply against 1.29.2.