### PR TITLE
Fix output location of 1.39.0 build artifacts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,8 +12,8 @@ echo "Building mrustc ${mrustc_version}"
 make -j$(nproc) -f minicargo.mk bin/mrustc
 echo "Building rustc ${rustc_versions[0]}"
 make -j$(nproc) -f minicargo.mk RUSTCSRC
-make -j$(nproc) -f minicargo.mk output/rustc
-make -j$(nproc) -f minicargo.mk output/cargo
+make -j$(nproc) -f minicargo.mk "output-${rustc_version[0]}/rustc"
+make -j$(nproc) -f minicargo.mk "output-${rustc_version[0]}/cargo"
 cd "/build/mrustc-${mrustc_version}/run_rustc"
 make -j$(nproc)
 

--- a/configs/rustc-1.40.0/config.toml
+++ b/configs/rustc-1.40.0/config.toml
@@ -1,6 +1,6 @@
 [build]
-cargo = "/build/mrustc-0.10.1/run_rustc/output/prefix/bin/cargo"
-rustc = "/build/mrustc-0.10.1/run_rustc/output/prefix/bin/rustc"
+cargo = "/build/mrustc-0.10.1/run_rustc/output-1.39.0/prefix/bin/cargo"
+rustc = "/build/mrustc-0.10.1/run_rustc/output-1.39.0/prefix/bin/rustc"
 docs = false
 vendor = true
 extended = true


### PR DESCRIPTION
Since 1.39.0 is different from mrustc's default choice of rustc starting point, it names the makefile targets and output directory with a suffix.