### PR TITLE
Set MRUSTC_TARGET_VER

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@ source /build/versions.sh
 
 cd "/build/mrustc-${mrustc_version}"
 export LIBSSH2_SYS_USE_PKG_CONFIG=true
+export MRUSTC_TARGET_VER="${rustc_versions[0]%.*}"
 export PARLEVEL="$(nproc)"
 export RUSTC_VERSION="${rustc_versions[0]}"
 echo "Building mrustc ${mrustc_version}"


### PR DESCRIPTION
Without this, building 1.39.0 fails with:

```console
error:0:Undefined language item 'non_zero' required
```

https://github.com/thepowersgang/mrustc/issues/188