### PR TITLE
Do without python-is-python3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,5 +23,5 @@ unset SUDO_USER
 for v in "${rustc_versions[@]:1}"; do
     cd "/build/rustc-$v"
     echo "Building rustc $v"
-    ./x.py build
+    python3 x.py build
 done

--- a/init.sh
+++ b/init.sh
@@ -14,7 +14,6 @@ deps=(
     make
     patch
     pkg-config
-    python-is-python3
     python3
     time
     zlib1g-dev


### PR DESCRIPTION
Prior to Rust 1.64, the x.py script uses a shebang of `#!/usr/bin/env python`. New ones use `#!/usr/bin/env python3`. On recent versions of Debian `python` is not available unless you have installed `python-is-python3`.