### PR TITLE
Only root user should be given write permission on chroot directory

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -34,6 +34,7 @@ done
 popd
 
 sudo chown root:root ./root
+sudo chmod u+w,g-w,o-w ./root
 sudo debootstrap --include=$(IFS=,; echo "${deps[*]}") bullseye ./root
 
 echo 'To enter the chroot:'


### PR DESCRIPTION
Fixes firejail error:

```console
Error: only root user should be given write permission on chroot directory
Error: proc 1781666 cannot sync with peer: unexpected EOF
Peer 1781667 unexpectedly exited with status 1
```