### PR TITLE
Update chroot from Debian 11 to 12

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -35,7 +35,7 @@ popd
 
 sudo chown root:root ./root
 sudo chmod u+w,g-w,o-w ./root
-sudo debootstrap --include=$(IFS=,; echo "${deps[*]}") bullseye ./root
+sudo debootstrap --include=$(IFS=,; echo "${deps[*]}") bookworm ./root
 
 echo 'To enter the chroot:'
 echo '$ firejail --chroot=./root --net=none --private-cwd=/build'


### PR DESCRIPTION
Fixes firejail error:

```console
/run/firejail/lib/fseccomp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /run/firejail/lib/fseccomp)
/run/firejail/lib/fseccomp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /run/firejail/lib/fseccomp)
/run/firejail/lib/fseccomp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /run/firejail/lib/fseccomp)
Error: failed to run /run/firejail/lib/fseccomp, exiting...
```