### PR TITLE
Update chroot from Debian 12 to 13

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -35,7 +35,7 @@ popd
 
 sudo chown root:root ./root
 sudo chmod u+w,g-w,o-w ./root
-sudo debootstrap --include=$(IFS=,; echo "${deps[*]}") bookworm ./root
+sudo debootstrap --include=$(IFS=,; echo "${deps[*]}") trixie ./root
 
 echo 'To enter the chroot:'
 echo '$ firejail --chroot=./root --net=none --private-cwd=/build'


### PR DESCRIPTION
Debian 12 is still on glibc 2.36. Still failing as follows after #16:

```console
/run/firejail/lib/fseccomp: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /run/firejail/lib/fseccomp)
Error: failed to run /run/firejail/lib/fseccomp, exiting...
```