### PR TITLE
Install perl FindBins

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -9,6 +9,7 @@ deps=(
     cmake
     g++
     libcurl4-openssl-dev
+    libfindbin-libs-perl
     libssh2-1-dev
     libssl-dev
     make


### PR DESCRIPTION
Without this, `openssl-sys` fails to build.

```console
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
    LANGUAGE = (unset),
    LC_ALL = (unset),
    LC_CTYPE = (unset),
    LC_NUMERIC = (unset),
    LC_COLLATE = (unset),
    LC_TIME = (unset),
    LC_MESSAGES = (unset),
    LC_MONETARY = (unset),
    LC_ADDRESS = (unset),
    LC_IDENTIFICATION = (unset),
    LC_MEASUREMENT = (unset),
    LC_PAPER = (unset),
    LC_TELEPHONE = (unset),
    LC_NAME = (unset),
    LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC entries checked: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.40.0 /usr/local/share/perl/5.40.0 /usr/lib/x86_64-linux-gnu/perl5/5.40 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.40 /usr/share/perl/5.40 /usr/local/lib/site_perl) at ./Configure line 15.
BEGIN failed--compilation aborted at ./Configure line 15.
thread 'main' panicked at :0:0:

Error configuring OpenSSL build:
    Command: cd "/build/mrustc-0.11.0/output-1.74.0/cargo-build/build_openssl-sys-0_9_92_H110/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=/build/mrustc-0.11.0/output-1.74.0/cargo-build/build_openssl-sys-0_9_92_H110/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-shared" "no-ssl3" "no-unit-test" "no-comp" "no-zlib" "no-zlib-dynamic" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "linux-x86_64" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-m64"
    Exit status: exit status: 2

Process was terminated with signal 6
FAILING COMMAND: /build/mrustc-0.11.0/output-1.74.0/cargo-build/build_openssl-sys-0_9_92_H110_run
Env:  CARGO_FEATURE_VENDORED=1 CARGO_FEATURE_OPENSSL_SRC=1 CARGO_FEATURE_DEP:OPENSSL_SRC=1 OUT_DIR=/build/mrustc-0.11.0/output-1.74.0/cargo-build/build_openssl-sys-0_9_92_H110 CARGO_MANIFEST_DIR=/build/mrustc-0.11.0/rustc-1.74.0-src/vendor/openssl-sys CARGO_PKG_NAME=openssl-sys CARGO_PKG_VERSION=0.9.92 CARGO_PKG_VERSION_MAJOR=0 CARGO_PKG_VERSION_MINOR=9 CARGO_PKG_VERSION_PATCH=92 TARGET=x86_64-unknown-linux-gnu HOST=x86_64-unknown-linux-gnu NUM_JOBS=1 OPT_LEVEL=2 DEBUG=0 PROFILE=release RUSTC=/build/mrustc-0.11.0/bin/mrustc MRUSTC_LIBDIR=/build/mrustc-0.11.0/output-1.74.0 CARGO_CFG_TARGET_VENDOR= CARGO_CFG_TARGET_VENDOR=gnu CARGO_CFG_TARGET_POINTER_WIDTH=64 CARGO_CFG_TARGET_OS=linux CARGO_CFG_TARGET_HAS_ATOMIC_LOAD_STORE=ptr CARGO_CFG_TARGET_HAS_ATOMIC_LOAD_STORE=8 CARGO_CFG_TARGET_HAS_ATOMIC_LOAD_STORE=64 CARGO_CFG_TARGET_HAS_ATOMIC_LOAD_STORE=32 CARGO_CFG_TARGET_HAS_ATOMIC_LOAD_STORE=16 CARGO_CFG_RUST_COMPILER=mrustc CARGO_CFG_TARGET_ABI=llvm CARGO_CFG_TARGET_HAS_ATOMIC_EQUAL_ALIGNMENT=8 CARGO_CFG_TARGET_HAS_ATOMIC_EQUAL_ALIGNMENT=ptr CARGO_CFG_TARGET_HAS_ATOMIC_EQUAL_ALIGNMENT=64 CARGO_CFG_TARGET_HAS_ATOMIC_EQUAL_ALIGNMENT=32 CARGO_CFG_TARGET_HAS_ATOMIC_EQUAL_ALIGNMENT=16 CARGO_CFG_TARGET_ENDIAN=little CARGO_CFG_TARGET_ARCH=x86_64 CARGO_CFG_TARGET_ENV=gnu CARGO_CFG_TARGET_HAS_ATOMIC=8 CARGO_CFG_TARGET_HAS_ATOMIC=cas CARGO_CFG_TARGET_HAS_ATOMIC=ptr CARGO_CFG_TARGET_HAS_ATOMIC=64 CARGO_CFG_TARGET_HAS_ATOMIC=32 CARGO_CFG_TARGET_HAS_ATOMIC=16 CARGO_CFG_TARGET_FAMILY=unix CARGO_CFG_UNIX=1 CARGO_CFG_LINUX=1
Calling output-1.74.0/cargo-build/build_openssl-sys-0_9_92_H110_run failed (see output-1.74.0/cargo-build/build_openssl-sys-0_9_92_H110.txt_failed.txt for stdout)
```