### PR TITLE
Ignore top-level directory name in mrustc tar

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -25,7 +25,8 @@ rsync -avP sources/ configs/ build.sh versions.sh root/build
 
 pushd root/build
 echo "Extracting mrustc ${mrustc_version}"
-tar xzf "mrustc-${mrustc_version}.tar.gz"
+mkdir -p "mrustc-${mrustc_version}"
+tar xzf "mrustc-${mrustc_version}.tar.gz" -C "mrustc-${mrustc_version}" --strip-components 1
 ln -s "../rustc-${rustc_versions[0]}-src.tar.gz" "mrustc-${mrustc_version}"
 for v in "${rustc_versions[@]:1}"; do
     echo "Extracting rustc $v"


### PR DESCRIPTION
This makes it easier to test against unreleased mrustc commits. The top-level directory in the tar might be something like "mrustc-994ddf817a554c48ae03840c8aaf82fb99ab5d27/".