### PR TITLE
Support using a specific commit of mrustc

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -9,7 +9,7 @@ cd sources
 
 echo "Downloading mrustc ${mrustc_version}"
 curl \
-    -L "https://github.com/thepowersgang/mrustc/archive/v${mrustc_version}.tar.gz" \
+    -L "https://github.com/thepowersgang/mrustc/archive/${mrustc_commit_override:-v${mrustc_version}}.tar.gz" \
     -o "mrustc-${mrustc_version}.tar.gz"
 
 for v in "${rustc_versions[@]}"; do


### PR DESCRIPTION
If `mrustc_commit_override` is set (in versions.sh or as an environment variable) then that mrustc commit will be used for the build. It does not have to be an officially published mrustc version.