### PR TITLE
Install ninja in chroot

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -13,6 +13,7 @@ deps=(
     libssh2-1-dev
     libssl-dev
     make
+    ninja-build
     patch
     pkg-config
     python3


### PR DESCRIPTION
This is required by recent versions of Rust since Rust 1.48 unless `ninja = false` is present in config.toml.

```console
Couldn't find required command: ninja (or ninja-build)

You should install ninja as described at
<https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages>,
or set `ninja = false` in the `[llvm]` section of `config.toml`.
Alternatively, set `download-ci-llvm = true` in that `[llvm]` section
to download LLVM rather than building it.
```