### PR TITLE
Disable download-ci-llvm for Rust 1.83+

### DIFF
--- a/configs/rustc-1.83.0/config.toml
+++ b/configs/rustc-1.83.0/config.toml
@@ -8,5 +8,8 @@ vendor = true
 extended = true
 tools = ["cargo"]
 
+[llvm]
+download-ci-llvm = false
+
 [rust]
 channel = "stable"


### PR DESCRIPTION
This is set to `true` by default since https://github.com/rust-lang/rust/pull/130529, causing:

```console
downloading https://ci-artifacts.rust-lang.org/rustc-builds/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/rust-dev-1.83.0-x86_64-unknown-linux-gnu.tar.xz
failed to execute command: "curl" "--location" "--speed-time" "30" "--speed-limit" "10" "--connect-timeout" "30" "--output" "/build/rustc-1.83.0/build/tmp/rust-dev-1.83.0-x86_64-unknown-linux-gnu.tar.xz" "--continue-at" "-" "--retry" "3" "--show-error" "--remote-time" "--fail" "--progress-bar" "https://ci-artifacts.rust-lang.org/rustc-builds/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/rust-dev-1.83.0-x86_64-unknown-linux-gnu.tar.xz" (failure_mode=Exit)
ERROR: Permission denied (os error 13)
ERROR: failed to download llvm from ci

    HELP: There could be two reasons behind this:
        1) The host triple is not supported for `download-ci-llvm`.
        2) Old builds get deleted after a certain time.
    HELP: In either case, disable `download-ci-llvm` in your config.toml:

    [llvm]
    download-ci-llvm = false
    
Build completed unsuccessfully in 0:00:26
```