### PR TITLE
Validate source hashes

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -14,7 +14,29 @@ curl \
 
 for v in "${rustc_versions[@]}"; do
     echo "Downloading rustc $v"
-    curl \
-        -L "https://static.rust-lang.org/dist/rustc-$v-src.tar.gz" \
-        -o "rustc-$v-src.tar.gz"
+
+    source_path="rustc-$v-src.tar.gz"
+    hash_path="rustc-$v-src.tar.gz.sha256"
+
+    if [[ ! -e "${hash_path}" ]]; then
+        curl \
+            -L "https://static.rust-lang.org/dist/${hash_path}" \
+            -o "${hash_path}"
+    fi
+
+    expected_hash="${rust_version_hashes[$v]}"
+    remote_expected_hash=$(cat rustc-$v-src.tar.gz.sha256)
+
+    if [[ "${expected_hash}" != "${remote_expected_hash}" ]]; then
+        echo 1>&2 "expected hash to be ${expected_hash}, got ${remote_expected_hash}"
+        exit 1
+    fi
+
+    if [[ ! -e "${source_path}" ]]; then
+        curl \
+            -L "https://static.rust-lang.org/dist/${source_path}" \
+            -o "${source_path}"
+    fi
+
+    sha256sum --check "$hash_path"
 done

--- a/versions.sh
+++ b/versions.sh
@@ -16,3 +16,18 @@ rustc_versions=(
     1.86.0
     1.87.0
 )
+declare -A rust_version_hashes
+rust_version_hashes["1.74.0"]="882b584bc321c5dcfe77cdaa69f277906b936255ef7808fcd5c7492925cf1049  rustc-1.74.0-src.tar.gz"
+rust_version_hashes["1.75.0"]="5b739f45bc9d341e2d1c570d65d2375591e22c2d23ef5b8a37711a0386abc088  rustc-1.75.0-src.tar.gz"
+rust_version_hashes["1.76.0"]="9e5cff033a7f0d2266818982ad90e4d3e4ef8f8ee1715776c6e25073a136c021  rustc-1.76.0-src.tar.gz"
+rust_version_hashes["1.77.2"]="c61457ef8f596638fddbc7716778b2f6b99ff12513a3b0f13994c3bc521638c3  rustc-1.77.2-src.tar.gz"
+rust_version_hashes["1.78.0"]="ff544823a5cb27f2738128577f1e7e00ee8f4c83f2a348781ae4fc355e91d5a9  rustc-1.78.0-src.tar.gz"
+rust_version_hashes["1.79.0"]="172ecf3c7d1f9d9fb16cd2a628869782670416ded0129e524a86751f961448c0  rustc-1.79.0-src.tar.gz"
+rust_version_hashes["1.80.1"]="2c0b8f643942dcb810cbcc50f292564b1b6e44db5d5f45091153996df95d2dc4  rustc-1.80.1-src.tar.gz"
+rust_version_hashes["1.81.0"]="872448febdff32e50c3c90a7e15f9bb2db131d13c588fe9071b0ed88837ccfa7  rustc-1.81.0-src.tar.gz"
+rust_version_hashes["1.82.0"]="7c53f4509eda184e174efa6ba7d5eeb586585686ce8edefc781a2b11a7cf512a  rustc-1.82.0-src.tar.gz"
+rust_version_hashes["1.83.0"]="722d773bd4eab2d828d7dd35b59f0b017ddf9a97ee2b46c1b7f7fac5c8841c6e  rustc-1.83.0-src.tar.gz"
+rust_version_hashes["1.84.1"]="5e2fb5d49628a549f7671b2ccf9855ab379fd442831a7c2af16e0cdcc31bb375  rustc-1.84.1-src.tar.gz"
+rust_version_hashes["1.85.1"]="0f2995ca083598757a8d9a293939e569b035799e070f419a686b0996fb94238a  rustc-1.85.1-src.tar.gz"
+rust_version_hashes["1.86.0"]="022a27286df67900a044d227d9db69d4732ec3d833e4ffc259c4425ed71eed80  rustc-1.86.0-src.tar.gz"
+rust_version_hashes["1.87.0"]="149bb9fd29be592da4e87900fc68f0629a37bf6850b46339dd44434c04fd8e76  rustc-1.87.0-src.tar.gz"


### PR DESCRIPTION
This makes sure that the downloaded hashes match:

* a local expected version
* the expected hash on the server
* the actual source tarball file hash

It uses the `sha256sum` tool to perform the hash validation.